### PR TITLE
Docker images used in CI/CD are getting rebuilt weekly

### DIFF
--- a/.github/workflows/ci-docker-image-build.yml
+++ b/.github/workflows/ci-docker-image-build.yml
@@ -1,0 +1,51 @@
+name: "CI Docker Image build"
+on:
+  schedule:
+    - cron: "10 2 * * 2"
+jobs:
+  build-docker-image:
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    name: 'Build Docker Image'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build Docker image - AMD dev
+        run: |
+          docker buildx build \
+            --target development \
+            --cache-to type=gha,mode=max,scope=amd-dev \
+            --load \
+            -t api:dev-amd \
+            -f ./docker/Dockerfile \
+            .
+          docker save api:dev-amd | gzip > api-dev-amd.tar.gz
+      - name: Build Docker image - AMD prod
+        run: |
+          docker buildx build \
+            --target production \
+            --cache-to type=gha,mode=max,scope=amd-prod \
+            --load \
+            --build-arg="VERSION=$( cat composer.json | jq -r .version )" \
+            -t api:prod-amd \
+            -f ./docker/Dockerfile \
+            .
+          docker save api:prod-amd | gzip > api-prod-amd.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-api-dev-amd
+          path: api-dev-amd.tar.gz
+          retention-days: 21
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-api-prod-amd
+          path: api-prod-amd.tar.gz
+          retention-days: 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase general test coverage to 28.2% (lines) and 54.1% (classes), increase mutant score indicator for covered code
   to 91%, closes #364. Feature tests do not count towards code coverage.
 - Add Docker build cache to CI/CD, closes #352.
+- Docker images used in CI/CD are getting rebuilt weekly, closes #369.
 ### Changed
 - Health state of production tests are getting printed in CI/CD, closes #362.
 - Mutant tests are now being executed on `buildjet-4vcpu-ubuntu-2204` to increase CI/CD speed.


### PR DESCRIPTION
### Added
- Docker images used in CI/CD are getting rebuilt weekly, closes #369.