### PR TITLE
specifying node and relation types which do not exist no longer crash…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Implement behavior in which the data payload of user registration endpoint is correctly normalized, fixes #282.
+- Specifying node and relation types which do not exist no longer crash the API, fixes #416.
 
 ## 0.1.28 - 2025-12-21
 ### Changed

--- a/tests/FeatureTests/Endpoint/Search/SearchTest.php
+++ b/tests/FeatureTests/Endpoint/Search/SearchTest.php
@@ -8,11 +8,144 @@ use App\Tests\FeatureTests\BaseRequestTestCase;
 
 class SearchTest extends BaseRequestTestCase
 {
-    private const string TOKEN = 'secret-token:OTYRavhRMtCilv30hiX617';
-    private const string PARENT_UUID = '1219e253-b147-4fa6-a567-5a79db2d2eb3';
+    private const string TOKEN = 'secret-token:1nc1pFdBO2QLYRMMvULgtQ';
 
-    public function testSearch(): void
+    public function testEmptySearchStepResultsInNoResults(): void
     {
-        $this->markTestSkipped('todo');
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
+        $data = $this->getBody($response);
+        $this->assertCount(0, $data['results']);
+    }
+
+    public function testElasticsearchSearchStepWorks(): void
+    {
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [
+                    [
+                        'type' => 'elasticsearch-query-dsl-mixin',
+                        'query' => [
+                            'match' => [
+                                'description' => [
+                                    'query' => 'lily',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
+    }
+
+    public function testNamingUndefinedNodeTypesInElasticsearchSearchQueryDoesNotLeadToCrash(): void
+    {
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [
+                    [
+                        'type' => 'elasticsearch-query-dsl-mixin',
+                        'query' => [
+                            'match' => [
+                                'description' => [
+                                    'query' => 'lily',
+                                ],
+                            ],
+                        ],
+                        'parameters' => [
+                            'nodeTypes' => [
+                                'TypeWhichDoesNotExist',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'element-hydration',
+                    ],
+                ],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
+    }
+
+    public function testNamingUndefinedRelationTypesInElasticsearchSearchQueryDoesNotLeadToCrash(): void
+    {
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [
+                    [
+                        'type' => 'elasticsearch-query-dsl-mixin',
+                        'query' => [
+                            'match' => [
+                                'description' => [
+                                    'query' => 'lily',
+                                ],
+                            ],
+                        ],
+                        'parameters' => [
+                            'relationTypes' => [
+                                'TYPE_WHICH_DOES_NOT_EXIST',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'element-hydration',
+                    ],
+                ],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
+    }
+
+    public function testCypherPathSubsetSearchStepWorks(): void
+    {
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [
+                    [
+                        'type' => 'cypher-path-subset',
+                        'query' => 'MATCH path=((:Plant)-[:HAS_TAG]->(:Tag {name: "blue"})) RETURN path',
+                    ],
+                ],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
+    }
+
+    public function testElementHydrationSearchStepWorks(): void
+    {
+        $response = $this->runPostRequest(
+            '/search',
+            self::TOKEN,
+            [
+                'steps' => [
+                    [
+                        'type' => 'element-hydration',
+                        'query' => [
+                            'elementIds' => [
+                                '258c0dfe-b1d8-4839-beed-d00d1b544a96',
+                                '3283fd3d-8083-4170-882a-41b1cd152c55',
+                                '8940d70b-5b6f-43b7-bee4-41d073396ff8',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertIsSearchResultResponse($response);
     }
 }


### PR DESCRIPTION
… the API, fixes #416